### PR TITLE
let httr build URL

### DIFF
--- a/R/categories.R
+++ b/R/categories.R
@@ -57,13 +57,18 @@ categories_in_page <- function(language = NULL, project = NULL, domain = NULL,
   } else {
     show_hidden <- "!hidden"
   }
-  url <- url_gen(language, project, domain,
-                 paste0("&action=query&prop=categories&clprop=", properties,
-                        "&clshow=", show_hidden, "&cllimit=", limit,
-                        "&titles=",pages))
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action = "query",
+    prop   = "categories",
+    clprop = properties,
+    clshow = show_hidden,
+    cllimit= limit,
+    titles = pages
+  )
   
   #Retrieve, check, return
-  content <- query(url, "pagecats", clean_response, ...)
+  content <- query(url, "pagecats", clean_response, query_param = query_param, ...)
   page_names <- names(unlist(content))
   missing_pages <- sum(grepl(x = page_names, pattern = "missing"))
   if(missing_pages){
@@ -138,10 +143,17 @@ pages_in_category <- function(language = NULL, project = NULL, domain = NULL, ca
   type <- paste(type, collapse = "|")
   
   #Construct URL
-  url <- url_gen(language, project, domain, "&action=query&list=categorymembers&cmtitle=",
-                categories, "&cmprop=", properties, "&cmtype=",type, "&cmlimit=", limit)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action  = "query",
+    list    = "categorymembers",
+    cmtitle = categories,
+    cmprop  = properties,
+    cmtype  = type,
+    cmlimit = limit
+  )
   
   #Query and return
-  content <- query(url, "catpages", clean_response, ...)
+  content <- query(url, "catpages", clean_response, query_param = query_param, ...)
   return(content)
 }

--- a/R/content.R
+++ b/R/content.R
@@ -53,11 +53,17 @@ random_page <- function(language = NULL, project = NULL, domain = NULL,
                         clean_response = FALSE, ...){
   
   
-  url <- url_gen(language, project, domain, "&action=query&list=random&rnlimit=", limit)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action  = "query",
+    list    = "random",
+    rnlimit = limit
+  )
+  
   if(!is.null(namespaces)){
-    url <- paste0(url, "&rnnamespace=", paste(namespaces, collapse = "|"))
+    query_param$rnnamespace <- paste(namespaces, collapse = "|")
   }
-  pages <- query(url, NULL, FALSE)$query$random
+  pages <- query(url, NULL, FALSE, query_param = query_param)$query$random
   
   return(lapply(pages, function(page, language, project, domain, page_name, as_wikitext,
                          clean_response, ...){
@@ -122,17 +128,19 @@ page_content <- function(language = NULL, project = NULL, domain = NULL,
     properties <- "text|revid"
   }
   properties <- paste(properties, collapse = "|")
-  url <- url_gen(language, project, domain, "&action=parse&prop=", properties)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action = "parse",
+    prop   = properties
+  )
   if(!is.null(page_id)){
-    page_id <- handle_limits(page_id, 1)
-    url <- paste0(url, "&pageid=", page_id)
+    query_param$page_id <- handle_limits(page_id, 1)
   } else {
-    page_name <- handle_limits(page_name, 1)
-    url <- paste0(url, "&page=", page_name)
+    query_param$page <- handle_limits(page_name, 1)
   }
   
   #Run  
-  content <- query(url, "pcontent", clean_response, ...)
+  content <- query(url, "pcontent", clean_response, query_param = query_param, ...)
   
   #Return
   return(content)
@@ -194,12 +202,17 @@ revision_content <- function(language = NULL, project = NULL, domain = NULL,
   properties <- match.arg(arg = properties, several.ok = TRUE)
   properties <- paste(properties, collapse = "|")
   revisions <- handle_limits(revisions, 50)
-  url <- url_gen(language, project, domain,
-                 "&rvcontentformat=text/x-wiki&action=query&prop=revisions&rvprop=",
-                 properties, "&revids=",revisions)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    rvcontentformat = "text/x-wiki",
+    action = "query",
+    prop   = "revisions",
+    rvprop = properties,
+    revids = revisions
+  )
   
   #Run
-  content <- query(url, "rcontent", clean_response, ...)
+  content <- query(url, "rcontent", clean_response, query_param = query_param, ...)
   
   #Check for invalid RevIDs
   invalid_revs(content)
@@ -277,13 +290,19 @@ revision_diff <- function(language = NULL, project = NULL, domain = NULL,
   properties <- match.arg(properties, several.ok = TRUE)
   properties <- paste(properties, collapse = "|")
   revisions <- handle_limits(revisions, 50)
-  url <- url_gen(language, project, domain, "&action=query&prop=revisions&rvprop=",
-                 properties, "&rvdiffto=", direction, "&rvcontentformat=text/css&revids=",
-                 revisions)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action   = "query",
+    prop     = "revisions",
+    rvprop   = properties, 
+    rvdiffto = direction,
+    rvcontentformat = "text/css",
+    revids   = revisions
+  )
   
   #Retrieve the content, check for invalid RevIDs and uncached diffs,
   #return.
-  content <- query(url, "rdiff", clean_response, ...)
+  content <- query(url, "rdiff", clean_response, query_param = query_param, ...)
   invalid_revs(content)
   if(sum(grepl(x = names(unlist(content)), pattern = "diff.notcached"))){
     warning("This request contained uncached diffs; these will not be returned", call. = FALSE)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -46,12 +46,19 @@ page_backlinks <- function(language = NULL, project = NULL, domain = NULL,
                            page, limit = 50, direction = "ascending", namespaces = NULL,
                            clean_response = FALSE, ...){
   
-  url <- url_gen(language, project, domain, "&action=query&list=backlinks&bltitle=", page,
-                 "&bldir=", direction, "&bllimit=", limit)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action  = "query",
+    list    = "backlinks",
+    bltitle = page,
+    bldir   = direction,
+    bllimit = limit
+  )
+  
   if(!is.null(namespaces)){
-    url <- paste0(url,"&blnamespace=",paste(namespaces, collapse = "|"))
+    query_param$blnamespace <- paste(namespaces, collapse = "|")
   }
-  content <- query(url, "blink", clean_response, ...)
+  content <- query(url, "blink", clean_response, query_param = query_param, ...)
   return(content)
 }
 
@@ -99,13 +106,19 @@ page_links <- function(language = NULL, project = NULL, domain = NULL,
                        page, limit = 50, direction = "ascending", namespaces = NULL,
                        clean_response = FALSE, ...){
   
-  url <- url_gen(language, project, domain, "&action=query&prop=links&titles=", page,
-                 "&pldir=", direction, "&pllimit=", limit)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action  = "query",
+    prop    = "links",
+    titles  = page,
+    pldir   = direction,
+    pllimit = limit
+  )
   
   if(!is.null(namespaces)){
-    url <- paste0(url,"&plnamespace=",paste(namespaces, collapse = "|"))
+    query_param$plnamespace <- paste(namespaces, collapse = "|")
   }
-  content <- query(url, "plink", clean_response, ...)
+  content <- query(url, "plink", clean_response, query_param = query_param, ...)
   return(content)  
 }
 
@@ -148,11 +161,16 @@ page_external_links <- function(language = NULL, project = NULL, domain = NULL,
                                 page, protocol = NULL, clean_response = FALSE,
                                 ...){
   
-  url <- url_gen(language, project, domain, "&action=query&prop=extlinks&titles=", page)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action = "query",
+    prop   = "extlinks",
+    titles = page
+  )
   if(!is.null(protocol)){
-    url <- paste0(url,"&elprotocol=", protocol)
+    query_param$elprotocol <- protocol
   }
-  content <- query(url, "elink", clean_response, ...)
+  content <- query(url, "elink", clean_response, query_param  = query_param, ...)
   return(content)
 }
 
@@ -195,7 +213,13 @@ page_info <- function(language = NULL, project = NULL, domain = NULL,
   
   properties <- match.arg(arg = properties, several.ok = TRUE)
   properties <- paste(properties, collapse = "|")
-  url <- url_gen(language, project, domain, "&action=query&prop=info&inprop=", properties, "&titles=", page)
-  content <- query(url, "pageinfo", clean_response, ...)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action = "query",
+    prop   = "info",
+    inprop = properties,
+    titles = page
+  )
+  content <- query(url, "pageinfo", clean_response, query_param = query_param, ...)
   return(content)
 }

--- a/R/query.R
+++ b/R/query.R
@@ -17,7 +17,9 @@
 #'@export
 query <- function(url, out_class, clean_response = FALSE, query_param = list(), ...){
   # Common query parameters
-  if(is.null(query_param$format)) query_param$format <- "json"
+  if(is.null(query_param$format)) {
+    query_param$format <- "json"
+  }
   
   args <- list(...)
   if(length(args) > 0 && "config" %in% class(args[[1]]) && "useragent" %in% names(args[[1]])){

--- a/R/query.R
+++ b/R/query.R
@@ -11,17 +11,19 @@
 #'@param clean_response whether to clean the response, using the method assigned
 #'by out_class, or not.
 #'
+#'@param query_param query parameters
+#'
 #'@param ... further arguments to httr's GET.
 #'@export
-query <- function(url, out_class, clean_response = FALSE, ...){
+query <- function(url, out_class, clean_response = FALSE, query_param = list(), ...){
+  # Common query parameters
+  if(is.null(query_param$format)) query_param$format <- "json"
   
-  #Encode url, add "http://", query
-  url <- paste0("http://",utils::URLencode(url))
   args <- list(...)
   if(length(args) > 0 && "config" %in% class(args[[1]]) && "useragent" %in% names(args[[1]])){
-    response <- httr::GET(url, ...)
+    response <- httr::GET(url, query = query_param, ...)
   } else {
-    response <- httr::GET(url, httr::user_agent("WikipediR - https://github.com/Ironholds/WikipediR"), ...)
+    response <- httr::GET(url, query = query_param, httr::user_agent("WikipediR - https://github.com/Ironholds/WikipediR"), ...)
   }
   
   #Check the validity of the response
@@ -46,12 +48,12 @@ url_gen <- function(language, project, domain = NULL, ...){
   if(is.null(domain)){
     #Commons and Wikispecies have different URL formats, so those have to be handled in a hinky way.
     if(project %in% c("commons","species")){
-      url <- paste0(project, ".wikimedia.org/w/api.php?format=json", ...)
+      url <- sprintf("http://%s.wikimedia.org/w/api.php", project)
     } else {
-      url <- paste0(language, "." ,project, ".org/w/api.php?format=json", ...)
+      url <- sprintf("http://%s.%s.org/w/api.php", language, project)
     }
   } else {
-    url <- paste0(domain,"/w/api.php?format=json", ...)
+    url <- sprintf("http://%s/w/api.php", domain)
   }
   
   #Return

--- a/R/query.R
+++ b/R/query.R
@@ -21,6 +21,11 @@ query <- function(url, out_class, clean_response = FALSE, query_param = list(), 
     query_param$format <- "json"
   }
   
+  # Add http scheme if url has no scheme
+  if(!any(startsWith(url, c("http://", "https://")))) {
+    url <- paste0("http://", url)
+  }
+  
   args <- list(...)
   if(length(args) > 0 && "config" %in% class(args[[1]]) && "useragent" %in% names(args[[1]])){
     response <- httr::GET(url, query = query_param, ...)

--- a/R/recent_changes.R
+++ b/R/recent_changes.R
@@ -62,17 +62,24 @@ recent_changes <- function(language = NULL, project = NULL, domain = NULL,
   type <- paste(type, collapse = "|")
   properties <- match.arg(arg = properties, several.ok = TRUE)
   properties <- paste(properties, collapse = "|")
-  url <- url_gen(language, project, domain, "&action=query&list=recentchanges&rcdir=",
-                 dir, "&rcprop=", properties, "&rctype=", type, "&rclimit=", limit)
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action = "query",
+    list   = "recentchanges",
+    rcdir  = dir,
+    rcprop = properties,
+    rctype = type,
+    rclimit= limit
+  )
   if(!is.null(tag)){
-    url <- paste0(url, "&rctag=", paste(tag, collapse = "|"))
+    query_param$rctag <-  paste(tag, collapse = "|")
   }
   if(top){
-    url <- paste0(url, "&rctoponly")
+    query_param$rctoponly <- ""
   }
   
   #Query
-  content <- query(url, "rchanges", clean_response, ...)
+  content <- query(url, "rchanges", clean_response, query_param = query_param, ...)
   
   #Return
   return(content)

--- a/R/user_info.R
+++ b/R/user_info.R
@@ -73,17 +73,22 @@ user_contributions <- function(language = NULL, project = NULL, domain = NULL,
   properties <- match.arg(properties, several.ok = TRUE)
   properties <- paste(properties, collapse = "|")
   username <- handle_limits(username, 1)
-  url <- url_gen(language, project, domain,
-                 paste0("&action=query&list=usercontribs&uclimit=", limit,
-                        "&ucuser=", username, "&ucprop=", properties))
+  url <- url_gen(language, project, domain)
+  query_param <- list(
+    action  = "query",
+    list    = "usercontribs",
+    uclimit = limit,
+    ucuser  = username,
+    ucprop  = properties
+  )
   
   #If only article contributions are desired, note that.
   if(mainspace){
-    url <- paste0(url, "&ucnamespace=0", sep = "")
+    query_param$ucnamespace <- 0
   }
   
   #Get, check and return
-  contribs_content <- query(url, "ucontribs", clean_response, ...)
+  contribs_content <- query(url, "ucontribs", clean_response, query_param = query_param, ...)
   missing_users(contribs_content)
   return(contribs_content)
 }
@@ -162,11 +167,17 @@ user_information <- function(language = NULL, project = NULL, domain = NULL,
   properties <- match.arg(properties, several.ok = TRUE)
   properties <- paste(properties, collapse = "|")
   user_names <- handle_limits(user_names, 50)
-  url <- url_gen(language, project, domain,
-                 paste0("&action=query&list=users&usprop=",properties,"&ususers=",user_names))
-  
+  url <- url_gen(language, project, domain)
+  query_param = list(
+    action  = "query",
+    list    = "users",
+    usprop  = properties,
+    ususers = user_names
+    
+  )
+
   #Retrieve the content, check it, return.
-  user_content <- query(url, "uinfo", clean_response, ...)
+  user_content <- query(url, "uinfo", clean_response, query_param = query_param, ...)
   missing_users(user_content)
   return(user_content)
   

--- a/man/query.Rd
+++ b/man/query.Rd
@@ -4,7 +4,7 @@
 \alias{query}
 \title{base query function}
 \usage{
-query(url, out_class, clean_response = FALSE, ...)
+query(url, out_class, clean_response = FALSE, query_param = list(), ...)
 }
 \arguments{
 \item{url}{a URL body}
@@ -14,6 +14,8 @@ WikidataR to indicate what response-cleaning method should be applied.}
 
 \item{clean_response}{whether to clean the response, using the method assigned
 by out_class, or not.}
+
+\item{query_param}{query parameters}
 
 \item{...}{further arguments to httr's GET.}
 }

--- a/tests/testthat/test_category_retrieval.R
+++ b/tests/testthat/test_category_retrieval.R
@@ -15,3 +15,8 @@ test_that("Category members can be retrieved through categories_in_page", {
 test_that("Category members can be retrieved through categories_in_page", {
   expect_true({pages_in_category("en","wikipedia", categories = "1920s births", type = "subcat");TRUE})
 })
+
+test_that("page categories can be retrieved through categories_in_page  with non-ASCII query", {
+  # \u30dd\u30b1\u30e2\u30f3 is "Pokemon" in Japanese letters
+  expect_true({categories_in_page("en","wikipedia", page = "\u30dd\u30b1\u30e2\u30f3");TRUE})
+})

--- a/tests/testthat/test_content_retrieval.R
+++ b/tests/testthat/test_content_retrieval.R
@@ -17,3 +17,8 @@ test_that("HTML content can be retrieved through revision_content", {
 test_that("Diffs can be retrieved through revision_content", {
   expect_true({revision_diff("en","wikipedia", revisions = "129122231", direction = "next");TRUE})
 })
+
+test_that("Wikitext content can be retrieved through page_content with non-ASCII query", {
+  # \u30dd\u30b1\u30e2\u30f3 is "Pokemon" in Japanese letters
+  expect_true({page_content("en","wikipedia", page_name = "\u30dd\u30b1\u30e2\u30f3", as_wikitext=TRUE);TRUE})
+})


### PR DESCRIPTION
fixes #9

Note that there is one breaking change; `query()` gets `query_param` arg. Those who use `query()` with unnamed argument may suffer from this change (but I bet there are very few...)