### PR TITLE
Adding extra user-defined query (partial fix to do cmcontinue)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
 BugReports: https://github.com/Ironholds/WikipediR/issues
 URL: https://github.com/Ironholds/WikipediR/
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1

--- a/R/categories.R
+++ b/R/categories.R
@@ -66,7 +66,7 @@ categories_in_page <- function(language = NULL, project = NULL, domain = NULL,
     cllimit= limit,
     titles = pages
   )
-  
+    
   #Retrieve, check, return
   content <- query(url, "pagecats", clean_response, query_param = query_param, ...)
   page_names <- names(unlist(content))
@@ -113,6 +113,8 @@ categories_in_page <- function(language = NULL, project = NULL, domain = NULL,
 #'@param limit The maximum number of members to retrieve for each category. Set
 #'to 50 by default.
 #'
+#'@param extra_query The list of additional parameters (optional).
+#'
 #'@param ... further arguments to pass to httr's GET().
 #'
 #'@section warnings:
@@ -132,6 +134,7 @@ categories_in_page <- function(language = NULL, project = NULL, domain = NULL,
 pages_in_category <- function(language = NULL, project = NULL, domain = NULL, categories,
                               properties = c("title","ids","sortkey","sortkeyprefix","type","timestamp"),
                               type = c("page","subcat","file"), clean_response = FALSE, limit = 50,
+                              extra_query = list(),
                               ...){
   
   #Format and check
@@ -153,6 +156,9 @@ pages_in_category <- function(language = NULL, project = NULL, domain = NULL, ca
     cmlimit = limit
   )
   
+  # Add user-defined query
+  query_param <- c(query_param, extra_query)
+
   #Query and return
   content <- query(url, "catpages", clean_response, query_param = query_param, ...)
   return(content)

--- a/man/WikipediR.Rd
+++ b/man/WikipediR.Rd
@@ -4,7 +4,6 @@
 \name{WikipediR}
 \alias{WikipediR}
 \alias{WikipediR-package}
-\alias{WikipediR-package}
 \title{A client library for MediaWiki's API}
 \description{
 This package provides functions for accessing the MediaWiki API, either for

--- a/man/categories_in_page.Rd
+++ b/man/categories_in_page.Rd
@@ -4,9 +4,17 @@
 \alias{categories_in_page}
 \title{Retrieves categories associated with a page.}
 \usage{
-categories_in_page(language = NULL, project = NULL, domain = NULL, pages,
-  properties = c("sortkey", "timestamp", "hidden"), limit = 50,
-  show_hidden = FALSE, clean_response = FALSE, ...)
+categories_in_page(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  pages,
+  properties = c("sortkey", "timestamp", "hidden"),
+  limit = 50,
+  show_hidden = FALSE,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_backlinks.Rd
+++ b/man/page_backlinks.Rd
@@ -4,9 +4,17 @@
 \alias{page_backlinks}
 \title{Retrieve a page's backlinks}
 \usage{
-page_backlinks(language = NULL, project = NULL, domain = NULL, page,
-  limit = 50, direction = "ascending", namespaces = NULL,
-  clean_response = FALSE, ...)
+page_backlinks(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
+  limit = 50,
+  direction = "ascending",
+  namespaces = NULL,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_content.Rd
+++ b/man/page_content.Rd
@@ -4,8 +4,16 @@
 \alias{page_content}
 \title{Retrieves MediaWiki page content}
 \usage{
-page_content(language = NULL, project = NULL, domain = NULL, page_name,
-  page_id = NULL, as_wikitext = FALSE, clean_response = FALSE, ...)
+page_content(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page_name,
+  page_id = NULL,
+  as_wikitext = FALSE,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_external_links.Rd
+++ b/man/page_external_links.Rd
@@ -4,8 +4,15 @@
 \alias{page_external_links}
 \title{Retrieve a page's links}
 \usage{
-page_external_links(language = NULL, project = NULL, domain = NULL, page,
-  protocol = NULL, clean_response = FALSE, ...)
+page_external_links(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
+  protocol = NULL,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_info.Rd
+++ b/man/page_info.Rd
@@ -4,9 +4,15 @@
 \alias{page_info}
 \title{Retrieve information about a particular page}
 \usage{
-page_info(language = NULL, project = NULL, domain = NULL, page,
+page_info(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
   properties = c("protection", "talkid", "url", "displaytitle"),
-  clean_response = FALSE, ...)
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_links.Rd
+++ b/man/page_links.Rd
@@ -4,9 +4,17 @@
 \alias{page_links}
 \title{Retrieve a page's links}
 \usage{
-page_links(language = NULL, project = NULL, domain = NULL, page,
-  limit = 50, direction = "ascending", namespaces = NULL,
-  clean_response = FALSE, ...)
+page_links(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
+  limit = 50,
+  direction = "ascending",
+  namespaces = NULL,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/pages_in_category.Rd
+++ b/man/pages_in_category.Rd
@@ -4,10 +4,18 @@
 \alias{pages_in_category}
 \title{Retrieves a list of category members.}
 \usage{
-pages_in_category(language = NULL, project = NULL, domain = NULL,
-  categories, properties = c("title", "ids", "sortkey", "sortkeyprefix",
-  "type", "timestamp"), type = c("page", "subcat", "file"),
-  clean_response = FALSE, limit = 50, ...)
+pages_in_category(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  categories,
+  properties = c("title", "ids", "sortkey", "sortkeyprefix", "type", "timestamp"),
+  type = c("page", "subcat", "file"),
+  clean_response = FALSE,
+  limit = 50,
+  extra_query = list(),
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,
@@ -38,6 +46,8 @@ Set to FALSE by default.}
 
 \item{limit}{The maximum number of members to retrieve for each category. Set
 to 50 by default.}
+
+\item{extra_query}{The list of additional parameters (optional).}
 
 \item{...}{further arguments to pass to httr's GET().}
 }

--- a/man/random_page.Rd
+++ b/man/random_page.Rd
@@ -4,9 +4,16 @@
 \alias{random_page}
 \title{Retrieve the page content of a random MediaWiki page}
 \usage{
-random_page(language = NULL, project = NULL, domain = NULL,
-  namespaces = NULL, as_wikitext = FALSE, limit = 1,
-  clean_response = FALSE, ...)
+random_page(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  namespaces = NULL,
+  as_wikitext = FALSE,
+  limit = 1,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/recent_changes.Rd
+++ b/man/recent_changes.Rd
@@ -4,11 +4,20 @@
 \alias{recent_changes}
 \title{Retrieves entries from the RecentChanges feed}
 \usage{
-recent_changes(language = NULL, project = NULL, domain = NULL,
-  properties = c("user", "userid", "comment", "parsedcomment", "flags",
-  "timestamp", "title", "ids", "sizes", "redirect", "loginfo", "tags", "sha1"),
-  type = c("edit", "external", "new", "log"), tag = NULL, dir = "newer",
-  limit = 50, top = FALSE, clean_response = FALSE, ...)
+recent_changes(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  properties = c("user", "userid", "comment", "parsedcomment", "flags", "timestamp",
+    "title", "ids", "sizes", "redirect", "loginfo", "tags", "sha1"),
+  type = c("edit", "external", "new", "log"),
+  tag = NULL,
+  dir = "newer",
+  limit = 50,
+  top = FALSE,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/revision_content.Rd
+++ b/man/revision_content.Rd
@@ -4,10 +4,16 @@
 \alias{revision_content}
 \title{Retrieves MediaWiki revisions}
 \usage{
-revision_content(language = NULL, project = NULL, domain = NULL,
-  revisions, properties = c("content", "ids", "flags", "timestamp", "user",
-  "userid", "size", "sha1", "contentmodel", "comment", "parsedcomment", "tags"),
-  clean_response = FALSE, ...)
+revision_content(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  revisions,
+  properties = c("content", "ids", "flags", "timestamp", "user", "userid", "size",
+    "sha1", "contentmodel", "comment", "parsedcomment", "tags"),
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/revision_diff.Rd
+++ b/man/revision_diff.Rd
@@ -4,10 +4,17 @@
 \alias{revision_diff}
 \title{Generates a "diff" between a pair of revisions}
 \usage{
-revision_diff(language = NULL, project = NULL, domain = NULL, revisions,
-  properties = c("ids", "flags", "timestamp", "user", "userid", "size",
-  "sha1", "contentmodel", "comment", "parsedcomment", "tags", "flagged"),
-  direction, clean_response = FALSE, ...)
+revision_diff(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  revisions,
+  properties = c("ids", "flags", "timestamp", "user", "userid", "size", "sha1",
+    "contentmodel", "comment", "parsedcomment", "tags", "flagged"),
+  direction,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/user_contributions.Rd
+++ b/man/user_contributions.Rd
@@ -4,10 +4,18 @@
 \alias{user_contributions}
 \title{Retrieve user contributions}
 \usage{
-user_contributions(language = NULL, project = NULL, domain = NULL,
-  username, properties = c("ids", "title", "timestamp", "comment",
-  "parsedcomment", "size", "sizediff", "flags", "tags"), mainspace = FALSE,
-  limit = 50, clean_response = FALSE, ...)
+user_contributions(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  username,
+  properties = c("ids", "title", "timestamp", "comment", "parsedcomment", "size",
+    "sizediff", "flags", "tags"),
+  mainspace = FALSE,
+  limit = 50,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/user_information.Rd
+++ b/man/user_information.Rd
@@ -4,10 +4,16 @@
 \alias{user_information}
 \title{Retrieve user information}
 \usage{
-user_information(language = NULL, project = NULL, domain = NULL,
-  user_names, properties = c("blockinfo", "groups", "implicitgroups",
-  "rights", "editcount", "registration", "emailable", "gender"),
-  clean_response = FALSE, ...)
+user_information(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  user_names,
+  properties = c("blockinfo", "groups", "implicitgroups", "rights", "editcount",
+    "registration", "emailable", "gender"),
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,


### PR DESCRIPTION
I had the same issue with #27 on pulling more than 500 responses. I added `extra_query` argument to `pages_in_category()` so that I can pass `cmcontinue` to queries. This is not a full fix for #27, but at least I can perform multiple `pages_in_category()` to use `cmcotinue`. Hope this helps a bit!