### PR TITLE
User Retrival: Add possibility to use `continue` parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
 BugReports: https://github.com/Ironholds/WikipediR/issues
 URL: https://github.com/Ironholds/WikipediR/
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.2

--- a/R/user_info.R
+++ b/R/user_info.R
@@ -46,7 +46,7 @@ missing_users <- function(parsed_response){
 #'@param clean_response whether to do some basic sanitising of the resulting data structure.
 #'Set to FALSE by default.
 #'
-#'@param continue wether to continue to next batch of responses. If so, add "continue token" as parameter
+#'@param continue When more results are available, use this to continue as input parameter for next request.
 #'
 #'@param ... further arguments to pass to httr's GET.
 #'
@@ -62,6 +62,12 @@ missing_users <- function(parsed_response){
 #'#Retrieve the timestamps of a user's recent contributions to a non-Wikimedia wiki.
 #'rw_contribs <- user_contributions(domain = "rationalwiki.org", username = "David Gerard",
 #'                                  properties = "ids", limit = 1)
+#' 
+#' #Retrieve data with continue parameter
+#' batch_1 <- user_contributions(domain = "rationalwiki.org", username = "David Gerard", 
+#' properties = "ids", limit = 1)
+#' batch_2 <- user_contributions(domain = "rationalwiki.org", username = "David Gerard", 
+#' properties = "ids", limit = 1, continue = batch_1[["continue"]][["uccontinue"]])
 #'                            
 #'@export
 user_contributions <- function(language = NULL, project = NULL, domain = NULL,

--- a/R/user_info.R
+++ b/R/user_info.R
@@ -46,6 +46,8 @@ missing_users <- function(parsed_response){
 #'@param clean_response whether to do some basic sanitising of the resulting data structure.
 #'Set to FALSE by default.
 #'
+#'@param continue wether to continue to next batch of responses. If so, add "continue token" as parameter
+#'
 #'@param ... further arguments to pass to httr's GET.
 #'
 #'@seealso \code{\link{user_information}} for information about a specific user (or group of users),
@@ -67,6 +69,7 @@ user_contributions <- function(language = NULL, project = NULL, domain = NULL,
                                                         "comment", "parsedcomment", "size", 
                                                         "sizediff", "flags", "tags"),
                                mainspace = FALSE, limit = 50, clean_response = FALSE,
+                               continue = NULL,
                                ...){
   
   #Perform checks, construct URL
@@ -74,6 +77,7 @@ user_contributions <- function(language = NULL, project = NULL, domain = NULL,
   properties <- paste(properties, collapse = "|")
   username <- handle_limits(username, 1)
   url <- url_gen(language, project, domain)
+  
   query_param <- list(
     action  = "query",
     list    = "usercontribs",
@@ -81,6 +85,10 @@ user_contributions <- function(language = NULL, project = NULL, domain = NULL,
     ucuser  = username,
     ucprop  = properties
   )
+  
+  if (!is.null(continue)) {
+    query_param <- append(query_param, list(uccontinue = continue))
+  }
   
   #If only article contributions are desired, note that.
   if(mainspace){

--- a/man/WikipediR.Rd
+++ b/man/WikipediR.Rd
@@ -4,7 +4,6 @@
 \name{WikipediR}
 \alias{WikipediR}
 \alias{WikipediR-package}
-\alias{WikipediR-package}
 \title{A client library for MediaWiki's API}
 \description{
 This package provides functions for accessing the MediaWiki API, either for

--- a/man/categories_in_page.Rd
+++ b/man/categories_in_page.Rd
@@ -4,9 +4,17 @@
 \alias{categories_in_page}
 \title{Retrieves categories associated with a page.}
 \usage{
-categories_in_page(language = NULL, project = NULL, domain = NULL, pages,
-  properties = c("sortkey", "timestamp", "hidden"), limit = 50,
-  show_hidden = FALSE, clean_response = FALSE, ...)
+categories_in_page(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  pages,
+  properties = c("sortkey", "timestamp", "hidden"),
+  limit = 50,
+  show_hidden = FALSE,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_backlinks.Rd
+++ b/man/page_backlinks.Rd
@@ -4,9 +4,17 @@
 \alias{page_backlinks}
 \title{Retrieve a page's backlinks}
 \usage{
-page_backlinks(language = NULL, project = NULL, domain = NULL, page,
-  limit = 50, direction = "ascending", namespaces = NULL,
-  clean_response = FALSE, ...)
+page_backlinks(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
+  limit = 50,
+  direction = "ascending",
+  namespaces = NULL,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_content.Rd
+++ b/man/page_content.Rd
@@ -4,8 +4,16 @@
 \alias{page_content}
 \title{Retrieves MediaWiki page content}
 \usage{
-page_content(language = NULL, project = NULL, domain = NULL, page_name,
-  page_id = NULL, as_wikitext = FALSE, clean_response = FALSE, ...)
+page_content(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page_name,
+  page_id = NULL,
+  as_wikitext = FALSE,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_external_links.Rd
+++ b/man/page_external_links.Rd
@@ -4,8 +4,15 @@
 \alias{page_external_links}
 \title{Retrieve a page's links}
 \usage{
-page_external_links(language = NULL, project = NULL, domain = NULL, page,
-  protocol = NULL, clean_response = FALSE, ...)
+page_external_links(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
+  protocol = NULL,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_info.Rd
+++ b/man/page_info.Rd
@@ -4,9 +4,15 @@
 \alias{page_info}
 \title{Retrieve information about a particular page}
 \usage{
-page_info(language = NULL, project = NULL, domain = NULL, page,
+page_info(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
   properties = c("protection", "talkid", "url", "displaytitle"),
-  clean_response = FALSE, ...)
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/page_links.Rd
+++ b/man/page_links.Rd
@@ -4,9 +4,17 @@
 \alias{page_links}
 \title{Retrieve a page's links}
 \usage{
-page_links(language = NULL, project = NULL, domain = NULL, page,
-  limit = 50, direction = "ascending", namespaces = NULL,
-  clean_response = FALSE, ...)
+page_links(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  page,
+  limit = 50,
+  direction = "ascending",
+  namespaces = NULL,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/pages_in_category.Rd
+++ b/man/pages_in_category.Rd
@@ -4,10 +4,17 @@
 \alias{pages_in_category}
 \title{Retrieves a list of category members.}
 \usage{
-pages_in_category(language = NULL, project = NULL, domain = NULL,
-  categories, properties = c("title", "ids", "sortkey", "sortkeyprefix",
-  "type", "timestamp"), type = c("page", "subcat", "file"),
-  clean_response = FALSE, limit = 50, ...)
+pages_in_category(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  categories,
+  properties = c("title", "ids", "sortkey", "sortkeyprefix", "type", "timestamp"),
+  type = c("page", "subcat", "file"),
+  clean_response = FALSE,
+  limit = 50,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/random_page.Rd
+++ b/man/random_page.Rd
@@ -4,9 +4,16 @@
 \alias{random_page}
 \title{Retrieve the page content of a random MediaWiki page}
 \usage{
-random_page(language = NULL, project = NULL, domain = NULL,
-  namespaces = NULL, as_wikitext = FALSE, limit = 1,
-  clean_response = FALSE, ...)
+random_page(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  namespaces = NULL,
+  as_wikitext = FALSE,
+  limit = 1,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/recent_changes.Rd
+++ b/man/recent_changes.Rd
@@ -4,11 +4,20 @@
 \alias{recent_changes}
 \title{Retrieves entries from the RecentChanges feed}
 \usage{
-recent_changes(language = NULL, project = NULL, domain = NULL,
-  properties = c("user", "userid", "comment", "parsedcomment", "flags",
-  "timestamp", "title", "ids", "sizes", "redirect", "loginfo", "tags", "sha1"),
-  type = c("edit", "external", "new", "log"), tag = NULL, dir = "newer",
-  limit = 50, top = FALSE, clean_response = FALSE, ...)
+recent_changes(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  properties = c("user", "userid", "comment", "parsedcomment", "flags", "timestamp",
+    "title", "ids", "sizes", "redirect", "loginfo", "tags", "sha1"),
+  type = c("edit", "external", "new", "log"),
+  tag = NULL,
+  dir = "newer",
+  limit = 50,
+  top = FALSE,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/revision_content.Rd
+++ b/man/revision_content.Rd
@@ -4,10 +4,16 @@
 \alias{revision_content}
 \title{Retrieves MediaWiki revisions}
 \usage{
-revision_content(language = NULL, project = NULL, domain = NULL,
-  revisions, properties = c("content", "ids", "flags", "timestamp", "user",
-  "userid", "size", "sha1", "contentmodel", "comment", "parsedcomment", "tags"),
-  clean_response = FALSE, ...)
+revision_content(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  revisions,
+  properties = c("content", "ids", "flags", "timestamp", "user", "userid", "size",
+    "sha1", "contentmodel", "comment", "parsedcomment", "tags"),
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/revision_diff.Rd
+++ b/man/revision_diff.Rd
@@ -4,10 +4,17 @@
 \alias{revision_diff}
 \title{Generates a "diff" between a pair of revisions}
 \usage{
-revision_diff(language = NULL, project = NULL, domain = NULL, revisions,
-  properties = c("ids", "flags", "timestamp", "user", "userid", "size",
-  "sha1", "contentmodel", "comment", "parsedcomment", "tags", "flagged"),
-  direction, clean_response = FALSE, ...)
+revision_diff(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  revisions,
+  properties = c("ids", "flags", "timestamp", "user", "userid", "size", "sha1",
+    "contentmodel", "comment", "parsedcomment", "tags", "flagged"),
+  direction,
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/man/user_contributions.Rd
+++ b/man/user_contributions.Rd
@@ -4,10 +4,19 @@
 \alias{user_contributions}
 \title{Retrieve user contributions}
 \usage{
-user_contributions(language = NULL, project = NULL, domain = NULL,
-  username, properties = c("ids", "title", "timestamp", "comment",
-  "parsedcomment", "size", "sizediff", "flags", "tags"), mainspace = FALSE,
-  limit = 50, clean_response = FALSE, ...)
+user_contributions(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  username,
+  properties = c("ids", "title", "timestamp", "comment", "parsedcomment", "size",
+    "sizediff", "flags", "tags"),
+  mainspace = FALSE,
+  limit = 50,
+  clean_response = FALSE,
+  continue = NULL,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,
@@ -41,6 +50,8 @@ and putting in more than 50 will generate a warning.}
 \item{clean_response}{whether to do some basic sanitising of the resulting data structure.
 Set to FALSE by default.}
 
+\item{continue}{When more results are available, use this to continue as input parameter for next request.}
+
 \item{...}{further arguments to pass to httr's GET.}
 }
 \description{
@@ -56,6 +67,12 @@ contribs <- user_contributions("en", "wikipedia", username = "Ironholds",
 #Retrieve the timestamps of a user's recent contributions to a non-Wikimedia wiki.
 rw_contribs <- user_contributions(domain = "rationalwiki.org", username = "David Gerard",
                                  properties = "ids", limit = 1)
+
+#Retrieve data with continue parameter
+batch_1 <- user_contributions(domain = "rationalwiki.org", username = "David Gerard", 
+properties = "ids", limit = 1)
+batch_2 <- user_contributions(domain = "rationalwiki.org", username = "David Gerard", 
+properties = "ids", limit = 1, continue = batch_1[["continue"]][["uccontinue"]])
                            
 }
 \seealso{

--- a/man/user_information.Rd
+++ b/man/user_information.Rd
@@ -4,10 +4,16 @@
 \alias{user_information}
 \title{Retrieve user information}
 \usage{
-user_information(language = NULL, project = NULL, domain = NULL,
-  user_names, properties = c("blockinfo", "groups", "implicitgroups",
-  "rights", "editcount", "registration", "emailable", "gender"),
-  clean_response = FALSE, ...)
+user_information(
+  language = NULL,
+  project = NULL,
+  domain = NULL,
+  user_names,
+  properties = c("blockinfo", "groups", "implicitgroups", "rights", "editcount",
+    "registration", "emailable", "gender"),
+  clean_response = FALSE,
+  ...
+)
 }
 \arguments{
 \item{language}{The language code of the project you wish to query,

--- a/tests/testthat/test_user_info_retrieval.R
+++ b/tests/testthat/test_user_info_retrieval.R
@@ -1,0 +1,27 @@
+context("User info")
+
+test_that("Response of requests of limit = 1 using continuation is the same as response with limit = 2", {
+  expect_true({
+    domain <- "wikidata.org"
+    project <- "wikidata"
+    user <- c("Removena")
+    
+    # Get all contributions ---------------------------------------------------
+    contributions_batch_1 <- user_contributions(domain = domain, project = project, username = user, limit = 1)
+    rvcontinue <- contributions_batch_1[["continue"]][["uccontinue"]]
+    contributions_batch_2 <- user_contributions(domain = domain, project = project, username = user, limit = 1, continue = rvcontinue)
+    
+    batch_list <- append(
+      contributions_batch_1[["query"]][["usercontribs"]], 
+      contributions_batch_2[["query"]][["usercontribs"]]
+    )
+    
+    # test list
+    contributions_test <- user_contributions(domain = domain, project = project, username = user, limit = 2)
+    
+    # check if lists are identical
+    identical(batch_list, contributions_test[["query"]][["usercontribs"]])
+    
+    ; TRUE
+  })
+})


### PR DESCRIPTION
Using the `continue` parameter in `user_contributions()` allows retrieving more data than `limit = 500`.

See: https://www.mediawiki.org/wiki/API:Revisions on `rvcontinue`.

Added a test for it in `tests/testthat/test_user_info_retrieval.R`